### PR TITLE
Java 16に変更

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -24,9 +24,11 @@ install() {
   # Install spigot for amazon linux 2
   NEED_JAVA_16=`echo $VERSION | awk -F. '{if ( $1 > 1 || $2 >= 17) print "true"; else print "false";}'`
   echo $NEED_JAVA_16
-  if [ $NEED_JAVA_16 = true ]; then
+  if [ $NEED_JAVA_16 = "true" ]; then
     # Amazon Corretto 16 (openJDK)
-    sudo yum install -y https://corretto.aws/downloads/latest/amazon-corretto-16-x64-linux-jdk.rpm
+    sudo rpm --import https://yum.corretto.aws/corretto.key 
+    sudo curl -L -o /etc/yum.repos.d/corretto.repo https://yum.corretto.aws/corretto.repo
+    sudo yum install -y java-16-amazon-corretto-devel
   else
     # Amazon Corretto 8 (openJDK)
     sudo amazon-linux-extras enable corretto8

--- a/setup.sh
+++ b/setup.sh
@@ -22,9 +22,8 @@ install() {
   mkdir -p $INSTALLATION_PATH
 
   # Install spigot for amazon linux 2
-  # Amazon Corretto 8 (openJDK)
-  sudo amazon-linux-extras enable corretto8
-  sudo yum install -y java-1.8.0-amazon-corretto-devel
+  # Amazon Corretto 16 (openJDK)
+  sudo yum install -y https://corretto.aws/downloads/latest/amazon-corretto-16-x64-linux-jdk.rpm
 
   # Set config
   ln -s $CURRENT_PATH/src/* $INSTALLATION_PATH

--- a/setup.sh
+++ b/setup.sh
@@ -23,8 +23,7 @@ install() {
 
   # Install spigot for amazon linux 2
   NEED_JAVA_16=`echo $VERSION | awk -F. '{if ( $1 > 1 || $2 >= 17) print "true"; else print "false";}'`
-  echo $NEED_JAVA_16
-  if [ $NEED_JAVA_16 = "true" ]; then
+  if [ $NEED_JAVA_16 = true ]; then
     # Amazon Corretto 16 (openJDK)
     sudo rpm --import https://yum.corretto.aws/corretto.key 
     sudo curl -L -o /etc/yum.repos.d/corretto.repo https://yum.corretto.aws/corretto.repo

--- a/setup.sh
+++ b/setup.sh
@@ -22,8 +22,16 @@ install() {
   mkdir -p $INSTALLATION_PATH
 
   # Install spigot for amazon linux 2
-  # Amazon Corretto 16 (openJDK)
-  sudo yum install -y https://corretto.aws/downloads/latest/amazon-corretto-16-x64-linux-jdk.rpm
+  NEED_JAVA_16=`echo $VERSION | awk -F. '{if ( $1 > 1 || $2 >= 17) print "true"; else print "false";}'`
+  echo $NEED_JAVA_16
+  if [ $NEED_JAVA_16 = true ]; then
+    # Amazon Corretto 16 (openJDK)
+    sudo yum install -y https://corretto.aws/downloads/latest/amazon-corretto-16-x64-linux-jdk.rpm
+  else
+    # Amazon Corretto 8 (openJDK)
+    sudo amazon-linux-extras enable corretto8
+    sudo yum install -y java-1.8.0-amazon-corretto-devel
+  fi
 
   # Set config
   ln -s $CURRENT_PATH/src/* $INSTALLATION_PATH


### PR DESCRIPTION
## 関連チケット
- #10 

## 変更点
- インストール用スクリプトのJavaインストールをJava 8からJava 16に変更

## 注意点
- Java 16にJava 8との互換性がどれだけあるかわからないため、Minecraft 1.16が正常に動くかわからない

## 見ること
- できれば動作確認してほしい

