### PR TITLE
ローカルマシンからリモートマシンをプロビジョニングできる手順を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ cd ./gretel
 bash ./setup.sh install <Minecraft Version>
 ```
 
+- docker imageを利用して手元のマシンからEC2インスタンスをセットアップする
+
+```sh
+docker run --volume=$HOME/.ssh/<IDENTITY_FILE.pem>:/workspace/identity.pem ghcr.io/shokkunrf/gretel-provisioner:latest --minecraft <MINECRAFT_VERSION> -h <USER>@<IP_ADDRESS>
+```
+
 ### ゲームサーバ実行方法
 
 - EC2 インスタンス起動時に自動で起動する

--- a/provisioner/Dockerfile
+++ b/provisioner/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.9.4-slim-buster
+
+RUN apt update && \
+    apt install -y \
+        git \
+        ssh \
+        jq
+RUN python -m pip install --upgrade pip && \
+    pip install ansible
+
+COPY ./entrypoint.sh /workspace/entrypoint.sh
+COPY ./parser.py /workspace/parser.py
+COPY ./playbook.yml /workspace/playbook.yml
+
+WORKDIR /workspace
+ENTRYPOINT [ "./entrypoint.sh", "-i", "./identity.pem" ]

--- a/provisioner/entrypoint.sh
+++ b/provisioner/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+parameter=$(python ./parser.py $@)
+if [ "$parameter" = '' ]; then
+  echo 'args is invalid'
+  exit 1
+fi
+
+user=$(echo $parameter | jq -r .user)
+ip=$(echo $parameter | jq -r .ip)
+identity_file=$(echo $parameter | jq -r .identity_file)
+minecraft_version=$(echo $parameter | jq -r .minecraft_version)
+
+ansible-playbook -i $ip, -u $user --private-key=$identity_file --extra-vars minecraft_version=$minecraft_version ./playbook.yml

--- a/provisioner/parser.py
+++ b/provisioner/parser.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+
+import sys
+import json
+
+def get_parameters(args):
+  length = len(args)
+  if length == 0:
+    return None
+
+  options = {
+    '-i': '',
+    '-h': '',
+    '--minecraft': ''
+  }
+  for i, arg in enumerate(args):
+    if not arg.startswith('-'):
+      continue
+    if i+1 == length:
+      return None
+    options[arg] = args[i+1]
+
+  user, ip = options['-h'].split('@')
+  return {
+    'ip': ip,
+    'user': user,
+    'minecraft_version': options['--minecraft'],
+    'identity_file': options['-i'],
+  }
+
+def main():
+  args = sys.argv[1:]
+  parameters = get_parameters(args)
+  if parameters is None:
+    return
+
+  j = json.dumps(parameters)
+  print(j)
+  return
+
+if __name__ == '__main__':
+  main()

--- a/provisioner/playbook.yml
+++ b/provisioner/playbook.yml
@@ -1,0 +1,27 @@
+---
+
+- name: spigot installer
+  hosts: all
+  tasks:
+    - name: install utils
+      yum:
+        name=git
+      become: yes
+    - name: create repo
+      file:
+        path: /Repositories/gretel
+        state: directory
+        owner: ec2-user
+        group: ec2-user
+        mode: 0777
+      become: yes
+    - name: clone repo
+      ansible.builtin.git:
+        repo: https://github.com/shokkunrf/gretel.git
+        dest: /Repositories/gretel
+    - name: setup gretel
+      shell: bash /Repositories/gretel/setup.sh install {{ minecraft_version }}
+      args:
+        chdir: /Repositories/gretel
+      poll: 30
+      async: 900


### PR DESCRIPTION
## 関連チケット
- #12 

## 変更点
- リモートマシンのプロビジョニングを追加

## 注意点
- playbookの`setup gretel`の実行に5分くらいかかり、その間pollのログしか表示されないけど、実行はされているので中断しないでね

## 見ること
- できれば動作確認してほしい
