### PR TITLE
開発用のconfigを削除

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,5 +16,3 @@ services:
       - "25565:25565/udp"
       - "25575:25575/udp"
     stop_grace_period: "30s"
-    tty: true
-    command: sh


### PR DESCRIPTION
開発時にコンテナに入るために設定していたが、実行時にはコンテナ内に入る必要がないため不要になった