### PR TITLE
Minecraft 1.19 に対応する

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+max_line_length = 120
+tab_width = 4
+trim_trailing_whitespace = true
+
+[{*.yml, *.yaml}]
+indent_size = 2

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,12 +10,15 @@ RUN apk update && \
         screen
 
 # version check
+# TODO : Once stable openjdk18 is released, use in 1.19
 RUN if expr ${VERSION} : "^1\.[0-9]|1[0-6]\.[0-9]*$" > /dev/null ; then \
         apk add openjdk8; \
     elif expr ${VERSION} : "^1\.17\.[0-9]*$" > /dev/null ; then \
         apk add openjdk16; \
     elif expr ${VERSION} : "^1\.18\.[0-9]*$" > /dev/null ; then \
         apk add openjdk17; \
+    elif expr ${VERSION} : "^1\.19\.[0-9]*$" > /dev/null ; then \
+            apk add openjdk17; \
     else \
         echo 'Invalid version.' >&2; \
         exit 1; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,15 +11,17 @@ RUN apk update && \
 
 # version check
 # TODO : Once stable openjdk18 is released, use in 1.19
-RUN JDK_PACKAGE=$(sed -Ee 's/^1.([0-9]|1[0-6])(.[0-9]+)?$/openjdk8/g' <(echo "${VERSION}")); \
-    JDK_PACKAGE=$(sed -Ee 's/^1.17(.[0-9]+)?$/openjdk16/g' <(echo "${JDK_PACKAGE}")); \
-    JDK_PACKAGE=$(sed -Ee 's/^1.18(.[0-9]+)?$/openjdk17/g' <(echo "${JDK_PACKAGE}")); \
-    JDK_PACKAGE=$(sed -Ee 's/^1.19(.[0-9]+)?$/openjdk17/g' <(echo "${JDK_PACKAGE}")); \
-    if [[ "${JDK_PACKAGE}" == 'openjdk*' ]]; then \
-      apk add "${JDK_PACKAGE}"; \
+RUN if expr ${VERSION} : "^1\.[0-9]|1[0-6]\.[0-9]*$" > /dev/null ; then \
+        apk add openjdk8; \
+    elif expr ${VERSION} : "^1\.17\.[0-9]*$" > /dev/null ; then \
+        apk add openjdk16; \
+    elif expr ${VERSION} : "^1\.18\.[0-9]*$" > /dev/null ; then \
+        apk add openjdk17; \
+    elif expr ${VERSION} : "^1\.19\.[0-9]*$" > /dev/null ; then \
+            apk add openjdk17; \
     else \
-      echo 'Invalid version.' >&2; \
-      exit 1; \
+        echo 'Invalid version.' >&2; \
+        exit 1; \
     fi
 
 COPY ./entrypoint.sh /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,13 +11,13 @@ RUN apk update && \
 
 # version check
 # TODO : Once stable openjdk18 is released, use in 1.19
-RUN if expr ${VERSION} : "^1\.[0-9]|1[0-6]\.[0-9]*$" > /dev/null ; then \
+RUN if echo "${VERSION}" | grep -E '^1\.([0-9]|1[0-6])(\.[0-9]+)?$'; then \
         apk add openjdk8; \
-    elif expr ${VERSION} : "^1\.17\.[0-9]*$" > /dev/null ; then \
+    elif echo "${VERSION}" | grep -E '^1\.17(\.[0-9]+)?$'; then \
         apk add openjdk16; \
-    elif expr ${VERSION} : "^1\.18\.[0-9]*$" > /dev/null ; then \
+    elif echo "${VERSION}" | grep -E '^1\.18(\.[0-9]+)?$'; then \
         apk add openjdk17; \
-    elif expr ${VERSION} : "^1\.19\.[0-9]*$" > /dev/null ; then \
+    elif echo "${VERSION}" | grep -E '^1\.19(\.[0-9]+)?$'; then \
             apk add openjdk17; \
     else \
         echo 'Invalid version.' >&2; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN if echo "${VERSION}" | grep -E '^1\.([0-9]|1[0-6])(\.[0-9]+)?$'; then \
     elif echo "${VERSION}" | grep -E '^1\.18(\.[0-9]+)?$'; then \
         apk add openjdk17; \
     elif echo "${VERSION}" | grep -E '^1\.19(\.[0-9]+)?$'; then \
-            apk add openjdk17; \
+        apk add openjdk17; \
     else \
         echo 'Invalid version.' >&2; \
         exit 1; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,17 +11,15 @@ RUN apk update && \
 
 # version check
 # TODO : Once stable openjdk18 is released, use in 1.19
-RUN if expr ${VERSION} : "^1\.[0-9]|1[0-6]\.[0-9]*$" > /dev/null ; then \
-        apk add openjdk8; \
-    elif expr ${VERSION} : "^1\.17\.[0-9]*$" > /dev/null ; then \
-        apk add openjdk16; \
-    elif expr ${VERSION} : "^1\.18\.[0-9]*$" > /dev/null ; then \
-        apk add openjdk17; \
-    elif expr ${VERSION} : "^1\.19\.[0-9]*$" > /dev/null ; then \
-            apk add openjdk17; \
+RUN JDK_PACKAGE=$(sed -Ee 's/^1.([0-9]|1[0-6])(.[0-9]+)?$/openjdk8/g' <(echo "${VERSION}")); \
+    JDK_PACKAGE=$(sed -Ee 's/^1.17(.[0-9]+)?$/openjdk16/g' <(echo "${JDK_PACKAGE}")); \
+    JDK_PACKAGE=$(sed -Ee 's/^1.18(.[0-9]+)?$/openjdk17/g' <(echo "${JDK_PACKAGE}")); \
+    JDK_PACKAGE=$(sed -Ee 's/^1.19(.[0-9]+)?$/openjdk17/g' <(echo "${JDK_PACKAGE}")); \
+    if [[ "${JDK_PACKAGE}" == 'openjdk*' ]]; then \
+      apk add "${JDK_PACKAGE}"; \
     else \
-        echo 'Invalid version.' >&2; \
-        exit 1; \
+      echo 'Invalid version.' >&2; \
+      exit 1; \
     fi
 
 COPY ./entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
# 主な変更点

- Minecraft 1.19 に対応させました
- `expr` コマンドが動かなくなっていたので他の方法で同じロジックを記述しました
- フォーマットの差異を吸収するため、 EditorConfig を追加しました


# Links

resolve #29 
resolve #30
